### PR TITLE
Add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+*.sh text eol=lf
+*.ps1 text eol=crlf
+*.bat text eol=crlf


### PR DESCRIPTION
I had an issue when cloning on windows and then running in Linux DevContainer. Did not find the hooks. Fixed it with "sed -i 's/\r$//' /workspaces/moneta-agents/scripts/preprovision.sh"

To prevent these kind of issues, might make sense to include gitattributes. 