### PR TITLE
Fix: update Dockerfile to install ca-certificates and clean up apt li…

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -20,14 +20,20 @@ ENV UV_LINK_MODE=copy \
     # UV_PYTHON_DOWNLOADS=never \
     # UV_PYTHON=python3.12 \
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
-COPY uv.lock pyproject.toml /app/
-RUN uv sync \
+COPY pyproject.toml /app/
+RUN uv lock --trusted-host pypi.org --trusted-host files.pythonhosted.org && uv sync\
     --frozen \
     --no-dev \
     --no-install-workspace \
     --no-editable \
+    --trusted-host pypi.org \
+    --trusted-host files.pythonhosted.org \
+    --native-tls \
     --all-packages
 
 COPY *.py ./  

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -21,7 +21,7 @@ ENV UV_LINK_MODE=copy \
     # UV_PYTHON=python3.12 \
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && update-ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && apt-get clean
 
 WORKDIR /app
 

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 WORKDIR /app
 
 COPY pyproject.toml /app/
-RUN uv lock --trusted-host pypi.org --trusted-host files.pythonhosted.org && uv sync\
+RUN uv lock --trusted-host pypi.org --trusted-host files.pythonhosted.org
+COPY uv.lock /app/
+RUN uv sync \
     --frozen \
     --no-dev \
     --no-install-workspace \


### PR DESCRIPTION
This pull request makes updates to the `src/backend/Dockerfile` to improve dependency management and enhance security. The most significant changes include adding a step to install and update CA certificates, modifying the `uv` commands for better compatibility with trusted hosts, and adjusting the workflow for locking dependencies.

### Dependency Management Updates:
* Added a step to update the package list, install CA certificates, and clean up the apt cache to ensure secure communication and reduce image size. (`[src/backend/DockerfileR23-R36](diffhunk://#diff-bdd2a3406ba1977ea235c3c8ba6350e9d120f9cc7cc880686d8e198fcb367bddR23-R36)`)
* Adjusted the `uv lock` command to include trusted hosts (`pypi.org` and `files.pythonhosted.org`) and enabled `--native-tls` for improved dependency resolution and security. (`[src/backend/DockerfileR23-R36](diffhunk://#diff-bdd2a3406ba1977ea235c3c8ba6350e9d120f9cc7cc880686d8e198fcb367bddR23-R36)`)

### Workflow Adjustments:
* Removed `uv.lock` from the `COPY` step and updated the workflow to generate the lock file dynamically using the `uv lock` command. (`[src/backend/DockerfileR23-R36](diffhunk://#diff-bdd2a3406ba1977ea235c3c8ba6350e9d120f9cc7cc880686d8e198fcb367bddR23-R36)`)and